### PR TITLE
Do not use lint:ci in ESlint workflow for GHA

### DIFF
--- a/.github/workflows/frontend_code_analysis.yml
+++ b/.github/workflows/frontend_code_analysis.yml
@@ -51,7 +51,7 @@ jobs:
         id: eslint
         if: ${{ success() || failure() }}
         run: |
-          yarn run lint:ci
+          yarn run lint
 
       - name: i18n sync
         id: i18n


### PR DESCRIPTION
The `yarn lint:ci` command does not output anything, and in GHA we do not collect the `eslint.xml` anyways (as we used to do it in Jenkins), so it's useless right now.

Changing it to run the normal `yarn lint`